### PR TITLE
feat: Set Terraform required_version to >= 1.5

### DIFF
--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.5"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/infra/test/setup/versions.tf
+++ b/infra/test/setup/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.5"
   required_providers {
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
* Please see [this GitHub issue](https://github.com/GoogleCloudPlatform/terraform-google-three-tier-web-app/issues/144) about requiring a minimum Terraform version between 1.3-1.5 for the "Three-tier web app" JSS (Jump Start Solution).
* We'll need to do the above for all JSSs — including _this_ JSS.
